### PR TITLE
Attach memory area reference to `DirectByteBuffer`s

### DIFF
--- a/larray-buffer/src/main/java/xerial/larray/buffer/LBufferAPI.java
+++ b/larray-buffer/src/main/java/xerial/larray/buffer/LBufferAPI.java
@@ -394,7 +394,8 @@ public class LBufferAPI {
         int index = 0;
         while (pos < limit) {
             long blockLength = Math.min(limit - pos, blockSize);
-            result[index++] = UnsafeUtil.newDirectByteBuffer(address() + pos, (int) blockLength).order(ByteOrder.nativeOrder());
+            result[index++] = UnsafeUtil.newDirectByteBuffer(address() + pos, (int) blockLength, this)
+                    .order(ByteOrder.nativeOrder());
             pos += blockLength;
         }
         return result;
@@ -408,7 +409,7 @@ public class LBufferAPI {
      * @return
      */
     public ByteBuffer toDirectByteBuffer(long offset, int size) {
-        return UnsafeUtil.newDirectByteBuffer(address() + offset, size);
+        return UnsafeUtil.newDirectByteBuffer(address() + offset, size, this);
     }
 
     protected long offset() {

--- a/larray-buffer/src/main/java/xerial/larray/buffer/UnsafeUtil.java
+++ b/larray-buffer/src/main/java/xerial/larray/buffer/UnsafeUtil.java
@@ -28,12 +28,10 @@ public class UnsafeUtil {
 
     private static Constructor<?> findDirectByteBufferConstructor() {
         try {
-          return Class.forName("java.nio.DirectByteBuffer").getDeclaredConstructor(Long.TYPE, Integer.TYPE);
-        }
-        catch(ClassNotFoundException e) {
+            return Class.forName("java.nio.DirectByteBuffer").getDeclaredConstructor(Long.TYPE, Integer.TYPE, Object.class);
+        } catch (ClassNotFoundException e) {
             throw new IllegalStateException(String.format("Failed to find java.nio.DirectByteBuffer: $s", e.getMessage()));
-        }
-        catch(NoSuchMethodException e) {
+        } catch (NoSuchMethodException e) {
             throw new IllegalStateException(String.format("Failed to find constructor f java.nio.DirectByteBuffer: $s", e.getMessage()));
         }
     }
@@ -46,14 +44,16 @@ public class UnsafeUtil {
      *
      * @param addr
      * @param size
+     * @param att object holding the underlying memory to attach to the buffer.
+     *            This will prevent the garbage collection of the memory area that's
+     *            associated with the new <code>DirectByteBuffer</code>
      * @return
      */
-    public static ByteBuffer newDirectByteBuffer(long addr, int size)
-    {
+    public static ByteBuffer newDirectByteBuffer(long addr, int size, Object att) {
         dbbCC.setAccessible(true);
         Object b = null;
         try {
-            b = dbbCC.newInstance(new Long(addr), new Integer(size));
+            b = dbbCC.newInstance(new Long(addr), new Integer(size), att);
             return ByteBuffer.class.cast(b);
         } catch (Exception e) {
             throw new IllegalStateException(String.format("Failed to create DirectByteBuffer: %s", e.getMessage()));

--- a/larray/src/main/scala/xerial/larray/LArray.scala
+++ b/larray/src/main/scala/xerial/larray/LArray.scala
@@ -711,7 +711,7 @@ trait RawByteArray[A] extends LArray[A] {
    */
   def writeToArray(srcOffset: Long, dest: Array[Byte], destOffset: Int, length: Int): Int = {
     val writeLen = math.min(dest.length - destOffset, math.min(length, byteLength - srcOffset)).toInt
-    val b = xerial.larray.buffer.UnsafeUtil.newDirectByteBuffer(address + srcOffset, writeLen)
+    val b = xerial.larray.buffer.UnsafeUtil.newDirectByteBuffer(address + srcOffset, writeLen, this)
     b.get(dest, destOffset, writeLen)
     writeLen
   }
@@ -725,7 +725,7 @@ trait RawByteArray[A] extends LArray[A] {
    */
   def readFromArray(src: Array[Byte], srcOffset: Int, destOffset: Long, length: Int): Int = {
     val readLen = math.min(src.length - srcOffset, math.min(byteLength - destOffset, length)).toInt
-    val b = xerial.larray.buffer.UnsafeUtil.newDirectByteBuffer(address + destOffset, readLen)
+    val b = xerial.larray.buffer.UnsafeUtil.newDirectByteBuffer(address + destOffset, readLen, this)
     b.put(src, srcOffset, readLen)
     readLen
   }


### PR DESCRIPTION
This avoids garbage collection of the `LBufferAPI` instance as long as `DirectByteBuffer`s referring to the `LBufferAPI` memory area are alive.

Failing to do keep the reference results in a segmentation fault upon access to the `DirectByteBuffer` after a GC run.